### PR TITLE
Fix emission of online/offline events in smart-plug node

### DIFF
--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -88,13 +88,11 @@ module.exports = function(RED) {
                         if (EVENT_ACTIONS.indexOf(action) !== -1) enabledActions.push(action);
                     });
                     if (enabledActions.length > 0) {
-                        RED.log.info("Configured to trigger actions " +  enabledActions.join(", "));
                         context.set('action', enabledActions.join('|'));
                     } else {
-                        RED.log.info("Configured to trigger no actions");
                         context.set('action', '');
                     }
-                        }
+                }
             }
 
             // Process other input only if connected to client

--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -62,8 +62,8 @@ module.exports = function(RED) {
                     return;
                 }
                 if (node.isClientConnected()) {
-                    if (node.checkAction('getInfoEvents')) node.sendDeviceSysInfo()
-                    if (node.checkAction('getMeterEvents')) node.sendDeviceMeterInfo()
+                    if (node.checkAction('getInfoEvents')) node.sendDeviceSysInfo(true)
+                    if (node.checkAction('getMeterEvents')) node.sendDeviceMeterInfo(true)
                 } else {
                     node.status({fill:'red',shape:'ring',text:'Not reachable'});
                     node.sendDeviceOnlineEvent(false);
@@ -178,7 +178,7 @@ module.exports = function(RED) {
             context.get('action') !== null &&
             context.get('action').includes(action);
         };
-        node.sendDeviceSysInfo = function() {
+        node.sendDeviceSysInfo = function(as_event = false) {
             node.deviceInstance.getSysInfo()
             .then(info => {
                 if (info.relay_state === 1) {
@@ -191,6 +191,9 @@ module.exports = function(RED) {
                 let msg = {};
                 msg.payload = info;
                 msg.payload.timestamp = moment().format();
+                if (as_event) {
+                    msg.payload.eventType = "InfoEvent";
+                }
                 node.send(msg);
             }).catch(error => {return node.handleConnectionError(error)});
         };
@@ -212,7 +215,7 @@ module.exports = function(RED) {
                 node.send(msg);
             }).catch(error => {return node.handleConnectionError(error)});
         };
-        node.sendDeviceMeterInfo = function() {
+        node.sendDeviceMeterInfo = function(as_event = false) {
             node.deviceInstance.emeter.getRealtime()
             .then(info => {
                 const current = numeral(info.current_ma/1000.0).format('0.[000]');
@@ -226,6 +229,9 @@ module.exports = function(RED) {
                 const msg = {};
                 msg.payload = info;
                 msg.payload.timestamp = moment().format();
+                if (as_event) {
+                    msg.payload.eventType = "MeterEvent";
+                }
                 node.send(msg);
             }).catch(error => {return node.handleConnectionError(error)});
         };
@@ -235,6 +241,7 @@ module.exports = function(RED) {
                 msg.payload = {};
                 msg.payload.powerOn = powerOn;
                 msg.payload.timestamp = moment().format();
+                msg.payload.eventType = "PowerUpdateEvent";
                 node.send(msg);
             }
         };
@@ -244,6 +251,7 @@ module.exports = function(RED) {
                 msg.payload = {};
                 msg.payload.inUse = inUse;
                 msg.payload.timestamp = moment().format();
+                msg.payload.eventType = "InUseEvent";
                 node.send(msg);
             }
         };
@@ -253,6 +261,7 @@ module.exports = function(RED) {
                 msg.payload = {};
                 msg.payload.online = online;
                 msg.payload.timestamp = moment().format();
+                msg.payload.eventType = "OnlineEvent";
                 node.send(msg);
             }
         };

--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -32,6 +32,7 @@ module.exports = function(RED) {
                 node.deviceConnected = true;
                 node.deviceInstance = device;
                 node.status({fill:'yellow',shape:'dot',text:'Connected'});
+                node.sendDeviceOnlineEvent(true);
                 device.on('power-on', () => {node.sendPowerUpdateEvent(true)});
                 device.on('power-off', () => {node.sendPowerUpdateEvent(false)});
                 device.on('in-use', () => {node.sendInUseEvent(true)});
@@ -65,6 +66,7 @@ module.exports = function(RED) {
                     if (node.checkAction('getMeterEvents')) node.sendDeviceMeterInfo()
                 } else {
                     node.status({fill:'red',shape:'ring',text:'Not reachable'});
+                    node.sendDeviceOnlineEvent(false);
                     node.stopPolling();
                     return false;
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-tplink",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A collection of Node-RED nodes for TP-Link smart-home devices.",
   "homepage": "https://github.com/caseyjhol/node-red-contrib-tplink",
   "author": "Dragoiu Robert <dragoiu.robert@gmail.com> (https://facebook.com/dopepixels)",
@@ -8,7 +8,8 @@
     "Barney Rubble <felixls.pic@gmail.com> (http://acloudhub.info/resume/)",
     "Raj Amal <raj.amalw@gmail.com> (https://www.learn2crack.com)",
     "juggledad (https://github.com/juggledad)",
-    "Casey Holzer (https://github.com/caseyjhol)"
+    "Casey Holzer (https://github.com/caseyjhol)",
+    "Hans-Christian Ebke (https://github.com/hcebke)"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Currently, DeviceOnlineEvent and DeviceOffline event don't get emitted when the connection to the smart plug is successfully established or lost. These changes fix this.
- Currently, you can't configure which events get triggered by the smart-plug node the connection to the device has been successfully established. But since you don't know when that happened (due to lack of events being emitted), your only choice has been to retry until successful. These changes allow event configuration to happen before a connection is established.
- Currently, there is no easy way to branch the output of the smart-plug node depending on the type of event that generated them. These changes introduce a `msg.payload.eventType` property to fix this.