### PR TITLE
Bug fix to initiate polling of device

### DIFF
--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -31,6 +31,7 @@ module.exports = function(RED) {
             .then((device) => {
                 node.deviceConnected = true;
                 node.deviceInstance = device;
+				device.startPolling(parseInt(node.config.interval));
                 node.status({fill:'yellow',shape:'dot',text:'Connected'});
                 device.on('power-on', () => {node.sendPowerUpdateEvent(true)});
                 device.on('power-off', () => {node.sendPowerUpdateEvent(false)});


### PR DESCRIPTION
Smart plug node was not initiating the polling of the device, like the smart bulb node. This line fixes this issue.

Also, should these polling functions be using `config.eventInterval` instead of `config.internval`?