### PR TITLE
Multi-Plug Support - Patch2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ or you can use the Palette Manager in Node-RED.
 ```js
 {
 	"plug": 1 // whole number corresponding to "Plug" number on power strip.  Optional.
-	"state": true // true is "on", false is "off", "toggle" sets the opposite power state
+	"state": true // true is "on", false is "off", "toggle" or "switch" sets the opposite power state
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ or you can use the Palette Manager in Node-RED.
 
 ```js
 {
-	"state": true // true is "on", false is "off", "toggle" sets the opposite power state
+	"state": true // true is "on", false is "off", "toggle" or "switch" sets the opposite power state
 }
 ```
 
@@ -52,6 +52,8 @@ or you can use the Palette Manager in Node-RED.
 `false` - Turn off the device.
 
 `toggle` - Toggle opposite power state of the device.
+
+`switch` - Toggle opposite power state of the device.
 
 ## Multi-Plug On/Off
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,17 @@ Hue, Saturation, and Brightness (HSB) support for multicolor bulbs.
 
 `getOnlineEvents` - Subscribe to online/offline events.  Event emits on poll interval.
 
-*Multiple events can be used as an array via the `events` property.*
+*Multiple events can be used as an array via the `events` property or string separated by "|"..*
 
 ```js
 {
 	"events": ["getMeterUpdateEvents", "getPowerEvents"]
+}
+```
+or
+```js
+{
+	"getMeterUpdateEvents|getPowerEvents"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,7 @@ Hue, Saturation, and Brightness (HSB) support for multicolor bulbs.
 ```
 or
 ```js
-{
-	"getMeterUpdateEvents|getPowerEvents"
-}
+"getMeterUpdateEvents|getPowerEvents"
 ```
 
 # For developers

--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -91,9 +91,16 @@ module.exports = function (RED) {
                     node.sendInput(node.deviceInstance[0], msg.payload.state);
                 }
                 if (msg.payload.hasOwnProperty('events')) {
-                    msg.payload.events.forEach(event => {
-                        node.sendInput(node.deviceInstance[0], event);
-                    });
+					if (typeof msg.payload.events === 'array' || msg.payload.events instanceof Array) {
+						msg.payload.events.forEach(event => {
+							node.sendInput(node.deviceInstance[0], event);
+						});
+					} else if (msg.payload.events.includes("|")) {
+						let msg_temp = msg.payload.events.split("|");
+						msg_temp.forEach(event => {
+							node.sendInput(node.deviceInstance[0], event);
+						});
+					}
                 };
             } else if (typeof msg.payload === 'array' || msg.payload instanceof Array) {
                 msg.payload.forEach(event => {

--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -71,7 +71,7 @@ module.exports = function (RED) {
                             let msg_test = msg.payload.state.toUpperCase();
                             if (msg_test === 'TRUE' || msg_test === 'ON') msg.payload.state = true;
                             if (msg_test === 'FALSE' || msg_test === 'OFF') msg.payload.state = false;
-                        }
+                        };
                         if (msg.payload.state === 'toggle') {
                             promises.push(node.deviceInstance[0].togglePowerState());
                         } else {
@@ -89,7 +89,7 @@ module.exports = function (RED) {
                     node.sendInput(node.deviceInstance[msg.payload.plug], msg.payload.state);
                 } else if (msg.payload.hasOwnProperty('state')) {
                     node.sendInput(node.deviceInstance[0], msg.payload.state);
-                }
+                };
                 if (msg.payload.hasOwnProperty('events')) {
 					if (typeof msg.payload.events === 'array' || msg.payload.events instanceof Array) {
 						msg.payload.events.forEach(event => {

--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -100,6 +100,8 @@ module.exports = function (RED) {
 						msg_temp.forEach(event => {
 							node.sendInput(node.deviceInstance[0], event);
 						});
+					} else {
+						node.sendInput(node.deviceInstance[0], msg.payload.events);
 					}
                 };
             } else if (typeof msg.payload === 'array' || msg.payload instanceof Array) {

--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -72,7 +72,7 @@ module.exports = function (RED) {
                             if (msg_test === 'TRUE' || msg_test === 'ON') msg.payload.state = true;
                             if (msg_test === 'FALSE' || msg_test === 'OFF') msg.payload.state = false;
                         };
-                        if (msg.payload.state === 'toggle') {
+                        if (msg.payload.state === 'toggle' || msg.payload.state === 'switch') {
                             promises.push(node.deviceInstance[0].togglePowerState());
                         } else {
                             promises.push(node.deviceInstance[0].setPowerState(msg.payload.state));
@@ -132,6 +132,7 @@ module.exports = function (RED) {
                     device.setPowerState(input);
                     break;
                 case 'toggle':
+				case 'switch':
                     device.togglePowerState();
                     break;
                 case 'getInfo':

--- a/nodes/smart-plug.js
+++ b/nodes/smart-plug.js
@@ -99,6 +99,11 @@ module.exports = function (RED) {
                 msg.payload.forEach(event => {
                     node.sendInput(node.deviceInstance[0], event);
                 });
+			} else if (msg.payload.includes("|")) {
+				let msg_temp = msg.payload.split("|");
+				msg_temp.forEach(event => {
+                    node.sendInput(node.deviceInstance[0], event);
+                });
             } else {
                 node.sendInput(node.deviceInstance[0], msg.payload);
             };


### PR DESCRIPTION
Update to support use of "|" in separating events both as string and event property.  Also includes "switch" to toggle opposite state supporting past versions.