### PR TITLE
Bug fix for device init

### DIFF
--- a/nodes/tplink.js
+++ b/nodes/tplink.js
@@ -448,7 +448,7 @@ module.exports = function (RED) {
         placeholder: true,
         queue: []
       })
-      node.newDevice(this.config.deviceId)
+      node.connectDevice(this.config.deviceId)
     } else {
       // Otherwise, initialize status (with no devices)
       node.updateStatus()


### PR DESCRIPTION
Fixes error "TypeError: node.newDevice is not a function" that occurs when trying to initialize the node with device.