### PR TITLE
Adding DayStats capabilities for power consumption

### DIFF
--- a/nodes/kasa.js
+++ b/nodes/kasa.js
@@ -316,10 +316,10 @@ module.exports = function (RED) {
           promise = device.emeter.getRealtime()
           break
         case 'getMeterCurrentMonthDayStats':
-          promise = device.emeter.get_daystat(new Date().getFullYear(),new Date().getMonth())
+          promise = device.emeter.getDayStats(new Date().getFullYear(),new Date().getMonth())
           break
         case 'getMeterLastMonthDayStats':
-          promise = device.emeter.get_daystat(new Date().getFullYear()-(new Date().getMonth()===1),((new Date().getMonth())-1)%12)
+          promise = device.emeter.getDayStats(new Date().getFullYear()-(new Date().getMonth()===1),((new Date().getMonth())-1)%12)
           break
         case 'eraseStats':
           promise = device.emeter.eraseStats()

--- a/nodes/kasa.js
+++ b/nodes/kasa.js
@@ -316,10 +316,10 @@ module.exports = function (RED) {
           promise = device.emeter.getRealtime()
           break
         case 'getMeterCurrentMonthDayStats':
-          promise = device.emeter.getDayStats(new Date().getFullYear(),new Date().getMonth())
+          promise = device.emeter.getDayStats(new Date().getFullYear(),new Date().getMonth()+1)
           break
         case 'getMeterLastMonthDayStats':
-          promise = device.emeter.getDayStats(new Date().getFullYear()-(new Date().getMonth()===1),((new Date().getMonth())-1)%12)
+          promise = device.emeter.getDayStats(new Date().getFullYear()-(new Date().getMonth()===1),((new Date().getMonth())-1)%12+1)
           break
         case 'eraseStats':
           promise = device.emeter.eraseStats()

--- a/nodes/kasa.js
+++ b/nodes/kasa.js
@@ -315,6 +315,12 @@ module.exports = function (RED) {
         case 'getMeterInfo':
           promise = device.emeter.getRealtime()
           break
+        case 'getMeterCurrentMonthDayStats':
+          promise = device.emeter.get_daystat(new Date().getFullYear(),new Date().getMonth())
+          break
+        case 'getMeterLastMonthDayStats':
+          promise = device.emeter.get_daystat(new Date().getFullYear()-(new Date().getMonth()===1),((new Date().getMonth())-1)%12)
+          break
         case 'eraseStats':
           promise = device.emeter.eraseStats()
           break


### PR DESCRIPTION
I added two addtitional command cases to leverage getDayStats function from tplink-smarthome-api :
- "getMeterCurrentMonthDayStats" : to get days consumption statistics corresponding to current month
- "getMeterLastMonthDayStats" : to get days consumption statistics corresponding to last month
These two cases cover the available data to retrieve as the plug only record the 30 last days

I successfully tested these with nodered pushing the commands through msg.payload input.