### PR TITLE
Fix memory leak caused by failure to properly close

### DIFF
--- a/nodes/kasa.js
+++ b/nodes/kasa.js
@@ -474,13 +474,13 @@ module.exports = function (RED) {
 
     // Cleanup when node destroyed
     node.on('close', function () {
-      // NOTE: We reference node.client.devices here, just in case
-      // there were devices initialized on this client that did not
-      // make it into the node.devices map. This ensures no memory
-      // leaking in case of bugs/errors.
-      node.client.devices.forEach(device => {
-        device.stopPolling()
-        device.closeConnection()
+      // Important: All code in this function must be sure
+      // to not cause any errors. If any error is uncaught,
+      // cleanup may not finish properly and there will
+      // be a memory leak!
+      node.devices.forEach(device => {
+        device.stopPolling && device.stopPolling()
+        device.closeConnection && device.closeConnection()
       })
       node.client.stopDiscovery()
     })


### PR DESCRIPTION
This fix checks to make sure the `stopPolling` and `closeConnection` methods actually exist before calling them. If the device is a placeholder (i.e. was never actually connected), and an attempt is made to call these non-existent methods, then it will cause an error. The error will be caught by node-red but will cause the entire `node.on('close')` event callback to cease and therefore any other devices will not be disconnected. Those still-connected devices will continue to poll, resulting in a memory leak. By checking to make sure these methods exist, it will prevent an error from occurring, thereby prevent a memory leak.