### PR TITLE
correct docs related to startMeterEvents

### DIFF
--- a/nodes/kasa.html
+++ b/nodes/kasa.html
@@ -214,7 +214,7 @@
       <li><code>startInfoEvents/stopInfoEvents</code> - Subscribe to device info.  Emits on event poll interval.</li>
       <li><code>startInUseEvents/stopInUseEvents</code> - Subscribe to device usage events.  Emits on change only.</li>
       <li><code>startInUseUpdateEvents/stopInUseUpdateEvents</code> - Subscribe to device usage events.  Emits on event poll interval.</li>
-      <li><code>startMeterUpdateEvents/stopMeterUpdateEvents</code> - Subscribe to meter information events.  Emits on event poll interval.</li>
+      <li><code>startMeterEvents/stopMeterEvents</code> - Subscribe to meter information events.  Emits on event poll interval.</li>
       <li><code>startOnlineEvents/stopOnlineEvents</code> - Subscribe just to online/offline events.  Emits on connection poll interval.</li>
       <li><code>stopAllEvents</code> - Unsubscribe from all events.</li>
     </ul>


### PR DESCRIPTION
This PR would update the documentation to address #50. The payload for getting meter events is in fact `startMeterEvents` instead of `startMeterUpdateEvents`.