### PR TITLE
Bugfix - Allow Temperature mode  back to HSB mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Control a device by setting its properties.
 - Or as an object, all properties optional:
 	-  `state: true` | `on` | `false` | `off` - Set device on or off
 	-  `brightness: [1-100]` - Set brightness, if supported
-	-  `temperature: [2700-6500]` - Set brightness (in kelvin), if supported
+	-  `temperature: [2700-6500, 0]` - Set brightness (in kelvin), or zero to leave temperature mode and return to previous hsb value if supported 
 	-  `hsb: {hue, saturation, brightness}` - Set the color, if supported
 	-  `led: true` | `false` - Turn the LED on or off, if supported
 

--- a/nodes/kasa.js
+++ b/nodes/kasa.js
@@ -202,7 +202,7 @@ module.exports = function (RED) {
         if (
           input.hasOwnProperty('temperature') &&
           device.supportsColorTemperature &&
-          validateNumber('temperature', input.temperature, 2700, 6500)
+          (validateNumber('temperature', input.temperature, 2700, 6500) || input.temperature == 0)
         ) {
           promises.push(device.lighting.setLightState({ color_temp: input.temperature }))
         }
@@ -464,10 +464,10 @@ module.exports = function (RED) {
 
     // Helpers
     function validateNumber(propName, value, min, max) {
-      if ((value >= min && value <= max) || value === undefined) {
+      if (((value >= min && value <= max) || value === undefined) || value == 0) {
         return true
       } else {
-        node.error(`Invalid ${propName} value; Should be between ${min} and ${max}`)
+        node.error(`Invalid ${propName} value; Should be between ${min} and ${max} or 0`)
         return false
       }
     }


### PR DESCRIPTION
I had a an issue request yesterday that I have solved. I've branched tested and updated the code and would like to contribute back to the project.

--the problem--

Currently you can change bulb colors by setting HSB which works great. You can then select a temperature (say 2700) and the bulb will leave hsb mode and enter temperature mode. If you give the bulb a new HSB value, it will not change to a color. 
I noticed that when in hsb mode the temperature value reads zero. After some testing I've concluded that by setting the temperature to zero the bulb leaves temperature mode and returns to the last hsb value used (which is pretty cool).

--the fix--

I've added an OR to your IF statement that checks the range to include 2700 to 6500 OR 0 to respect your range but also allow zero. I've also updated the helper function to include 0 and the readme.md so people know they can use it.

Thanks again for a great implementation!